### PR TITLE
Google Service, & Forecast endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'fast_jsonapi'
 
 gem 'factory_bot_rails'
 gem 'faker'
+gem 'geocoder'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw] # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
     ffi (1.9.25)
     figaro (1.1.1)
       thor (~> 0.14)
+    geocoder (1.5.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashdiff (0.3.8)
@@ -243,6 +244,7 @@ DEPENDENCIES
   faraday
   fast_jsonapi
   figaro
+  geocoder
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/api/v1/forecasts_controller.rb
+++ b/app/controllers/api/v1/forecasts_controller.rb
@@ -1,0 +1,19 @@
+
+class Api::V1::ForecastsController < ApplicationController
+
+  def index
+    coords = ForecastHelper.new(location).get_coordinates
+
+    binding.pry
+  end
+
+
+
+
+  private
+
+  def location
+    location = params[:location] || request.location.city
+  end
+
+end

--- a/app/facades/forecast_helper.rb
+++ b/app/facades/forecast_helper.rb
@@ -1,0 +1,26 @@
+
+class ForecastHelper
+
+  def initialize( location )
+    @location = location
+  end
+
+
+  def get_coordinates
+    Coordinates.new( get_location ).pair
+  end
+
+
+  private
+
+  def get_location
+    GoogleService.new( location_target ).target_data
+  end
+
+  def location_target
+    target = { target: :address, location: @location }
+  end
+
+
+
+end

--- a/app/models/coordinates.rb
+++ b/app/models/coordinates.rb
@@ -1,0 +1,23 @@
+
+class Coordinates
+
+  def initialize(raw)
+    @raw  = raw
+    @location = raw[:results].first[:geometry][:location]
+  end
+
+  def pair
+    "#{lat},#{lng}"
+  end
+
+  private
+
+  def lat
+    @location[:lat]
+  end
+
+  def lng
+    @location[:lng]
+  end
+
+end

--- a/app/services/google_service.rb
+++ b/app/services/google_service.rb
@@ -1,0 +1,48 @@
+
+class GoogleService
+
+  def initialize(filter)
+    @base_url = 'https://maps.googleapis.com/maps/api/geocode/json'
+    @filter   = filter
+    @target   = filter[:target]
+  end
+
+  def target_data
+    get_json( format_query )
+  end
+
+
+  private
+
+  def endpoints
+    {
+      address: "?address=#{location}"
+    }
+  end
+
+  def target
+    endpoints[@target]
+  end
+
+  def key_param
+    "key=#{ENV['google_key']}"
+  end
+
+  def format_query
+    "#{target}&#{key_param}"
+  end
+
+  def location
+    @location ||= @filter[:location]  # we should validate that this is city,state somewhere ?
+  end
+
+  def get_json(url)
+    response = location_connection.get( url )
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def location_connection
+    Faraday.new(url: @base_url)
+  end
+
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,61 +1,37 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # In the development environment your application's code is reloaded on
-  # every request. This slows down response time but is perfect for development
-  # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.cache_classes = false # In the development environment your application's code is reloaded on   # every request. This slows down response time but is perfect for development   # since you don't have to restart the web server when you make code changes.
+  config.eager_load = false   # Do not eager load code on boot.
+  config.consider_all_requests_local = true # Show full error reports.
 
-  # Do not eager load code on boot.
-  config.eager_load = false
-
-  # Show full error reports.
-  config.consider_all_requests_local = true
-
-  # Enable/disable caching. By default caching is disabled.
-  # Run rails dev:cache to toggle caching.
+  # Enable/disable caching. By default caching is disabled.  # Run rails dev:cache to toggle caching.
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
-
     config.cache_store = :memory_store
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false
-
     config.cache_store = :null_store
   end
 
-  # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
-
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
+  config.active_storage.service = :local # Store uploaded files on the local file system (see config/storage.yml for options)
+  config.action_mailer.raise_delivery_errors = false # Don't care if the mailer can't send.
   config.action_mailer.perform_caching = false
-
-  # Print deprecation notices to the Rails logger.
-  config.active_support.deprecation = :log
-
-  # Raise an error on page load if there are pending migrations.
-  config.active_record.migration_error = :page_load
-
-  # Highlight code that triggered database queries in logs.
-  config.active_record.verbose_query_logs = true
-
-  # Debug mode disables concatenation and preprocessing of assets.
-  # This option may cause significant delays in view rendering with a large
-  # number of complex assets.
-  config.assets.debug = true
-
-  # Suppress logger output for asset requests.
-  config.assets.quiet = true
-
-  # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
-
-  # Use an evented file watcher to asynchronously detect changes in source code,
-  # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.active_support.deprecation = :log # Print deprecation notices to the Rails logger.
+  config.active_record.migration_error = :page_load # Raise an error on page load if there are pending migrations.
+  config.active_record.verbose_query_logs = true # Highlight code that triggered database queries in logs.
+  config.assets.debug = true # Debug mode disables concatenation and preprocessing of assets. # This option may cause significant delays in view rendering with a large # number of complex assets.
+  config.assets.quiet = true # Suppress logger output for asset requests.
+  # Raises error for missing translations # config.action_view.raise_on_missing_translations = true
+  config.file_watcher = ActiveSupport::EventedFileUpdateChecker # Use an evented file watcher to asynchronously detect changes in source code, # routes, locales, etc. This feature depends on the listen gem.
 end
+
+# https://stackoverflow.com/questions/18823532/fake-ip-for-geocoder-in-development-environment
+# class ActionController::Request
+#   def remote_ip
+#     "68.64.216.134"
+#   end
+# end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,46 +1,29 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # The test environment is used exclusively to run your application's
-  # test suite. You never need to work with it otherwise. Remember that
-  # your test database is "scratch space" for the test suite and is wiped
-  # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
-
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
-
-  # Configure public file server for tests with Cache-Control for performance.
-  config.public_file_server.enabled = true
+  config.cache_classes              = true # The test environment is used exclusively to run your application's   # test suite. You never need to work with it otherwise. Remember that   # your test database is "scratch space" for the test suite and is wiped  # and recreated between test runs. Don't rely on the data there!
+  config.eager_load                 = false # Do not eager load code on boot. This avoids loading your whole application # just for the purpose of running a single test. If you are using a tool that # preloads Rails for running tests, you may have to set it to true.
+  config.public_file_server.enabled = true # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.headers = {
     'Cache-Control' => "public, max-age=#{1.hour.to_i}"
   }
 
-  # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
-
-  # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
-
-  # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
-
-  # Store uploaded files on the local file system in a temporary directory
-  config.active_storage.service = :test
-
-  config.action_mailer.perform_caching = false
-
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
-
-  # Print deprecation notices to the stderr.
-  config.active_support.deprecation = :stderr
+  config.consider_all_requests_local                = true # Show full error reports and disable caching.
+  config.action_controller.perform_caching          = false
+  config.action_dispatch.show_exceptions            = false # Raise exceptions instead of rendering exception templates.
+  config.action_controller.allow_forgery_protection = false # Disable request forgery protection in test environment.
+  config.active_storage.service                     = :test # Store uploaded files on the local file system in a temporary directory
+  config.action_mailer.perform_caching              = false
+  config.action_mailer.delivery_method              = :test # Tell Action Mailer not to deliver emails to the real world.   # The :test delivery method accumulates sent emails in the # ActionMailer::Base.deliveries array.
+  config.active_support.deprecation                 = :stderr # Print deprecation notices to the stderr.
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end
+
+# https://stackoverflow.com/questions/18823532/fake-ip-for-geocoder-in-development-environment
+# class ActionController::Request
+#   def remote_ip
+#     "68.64.216.134"
+#   end
+# end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,16 @@
+# For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  namespace :api do
+    namespace :v1 do
+      get 'forecasts', to: 'forecasts#index'
+    end
+  end
+
+
+
+
+
+
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,18 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/spec/api/coordinates_spec.rb
+++ b/spec/api/coordinates_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+
+describe "Coordinates" do
+
+  let(:location)    { "Denver,CO" }
+  let(:google)      { GoogleService.new( {target: :address, location: location}) }
+  let(:data)        { google.target_data }
+  let(:coordinates) { Coordinates.new(data) }
+  let(:pair)        { '39.7392358,-104.990251' }
+
+  # TO DO -- STUB HERE for the service object
+
+  before(:each) do
+    stub_geocode_denver
+  end
+
+
+  it 'initializes with raw data from google service' do
+    expect(coordinates.class).to eq(Coordinates)
+  end
+
+  it 'can provide a string-pair of latitude & longitude coordiantes' do
+    string = coordinates.pair
+    expect(string).to eq(pair)
+  end
+
+end

--- a/spec/api/forecast_helper_spec.rb
+++ b/spec/api/forecast_helper_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+
+describe "ForecastHelper" do
+
+  let(:location)    { 'Denver,CO' }
+  let(:coordinates) { '39.7392358,-104.990251' }
+  let(:helper)      { ForecastHelper.new(location) }
+
+  before(:each) do
+    stub_geocode_denver
+  end
+
+
+  it 'initializes with location' do
+    klass  = helper.class
+    expect(klass).to eq(ForecastHelper)
+  end
+
+  it 'gets coordinates' do
+    coords = helper.get_coordinates
+    expect(coords).to eq(coordinates)
+  end
+
+
+
+end

--- a/spec/api/v1/can_obtain_a_multiday_forecast_spec.rb
+++ b/spec/api/v1/can_obtain_a_multiday_forecast_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+
+describe "Can Obtain Forecast Data" do
+
+  let(:location) { "Denver,CO" }
+
+  before(:each) do
+    stub_geocode_denver
+    visit api_v1_forecasts_path(location: location)
+  end
+
+  it 'can get location from browser' do
+    skip('Make this a service test')
+  end
+
+  it 'can get forcast from location' do
+    binding.pry
+    skip('Make this a service test')
+  end
+
+
+
+
+end

--- a/spec/fixtures/api/v1/denver_geocode.json
+++ b/spec/fixtures/api/v1/denver_geocode.json
@@ -1,0 +1,74 @@
+{
+    "results": [
+        {
+            "address_components": [
+                {
+                    "long_name": "Denver",
+                    "short_name": "Denver",
+                    "types": [
+                        "locality",
+                        "political"
+                    ]
+                },
+                {
+                    "long_name": "Denver County",
+                    "short_name": "Denver County",
+                    "types": [
+                        "administrative_area_level_2",
+                        "political"
+                    ]
+                },
+                {
+                    "long_name": "Colorado",
+                    "short_name": "CO",
+                    "types": [
+                        "administrative_area_level_1",
+                        "political"
+                    ]
+                },
+                {
+                    "long_name": "United States",
+                    "short_name": "US",
+                    "types": [
+                        "country",
+                        "political"
+                    ]
+                }
+            ],
+            "formatted_address": "Denver, CO, USA",
+            "geometry": {
+                "bounds": {
+                    "northeast": {
+                        "lat": 39.91424689999999,
+                        "lng": -104.6002959
+                    },
+                    "southwest": {
+                        "lat": 39.614431,
+                        "lng": -105.109927
+                    }
+                },
+                "location": {
+                    "lat": 39.7392358,
+                    "lng": -104.990251
+                },
+                "location_type": "APPROXIMATE",
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.91424689999999,
+                        "lng": -104.6002959
+                    },
+                    "southwest": {
+                        "lat": 39.614431,
+                        "lng": -105.109927
+                    }
+                }
+            },
+            "place_id": "ChIJzxcfI6qAa4cR1jaKJ_j0jhE",
+            "types": [
+                "locality",
+                "political"
+            ]
+        }
+    ],
+    "status": "OK"
+}

--- a/spec/fixtures/stub_geocode_denver.rb
+++ b/spec/fixtures/stub_geocode_denver.rb
@@ -1,0 +1,14 @@
+
+module StubGeocodeDenver
+
+  def stub_geocode_denver
+    base  = 'https://maps.googleapis.com/maps/api/geocode/json'
+    query = '?address=Denver,CO'
+    key   = "&key=#{ENV['google_key']}"
+    url   = base+query+key
+    stub_request(:get, url).
+      to_return(body: File.read("./spec/fixtures/api/v1/denver_geocode.json"))
+  end
+
+
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,10 +33,14 @@ end
 
 require 'simplecov'
 SimpleCov.start "rails" do
-  add_filter 'app/channels/application_cable/channel.rb'
-  add_filter 'app/channels/application_cable/connection.rb'
-  add_filter 'app/helpers/application_helper.rb'
-  add_filter 'app/jobs/application_job.rb'
+  add_filter'/bin/'
+  add_filter'/db/'
+  add_filter'/spec/'
+  add_filter'/config/'
+  add_filter'/app/channels/'
+  add_filter'app/jobs/'
+  add_filter'app/mailers/'
+  add_filter'app/helpers/'
 end
 
 Shoulda::Matchers.configure do |config|
@@ -56,8 +60,8 @@ require 'webmock/rspec'
 #   config.configure_rspec_metadata!
 #   # config.filter_sensitive_data("<google_key>") { ENV['google_key'] }
 # end
-
-
+require './spec/fixtures/stub_geocode_denver'
+require 'capybara/rails'
 RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures" # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.use_transactional_fixtures = true              # If you're not using ActiveRecord, or you'd prefer not to run each of your # examples within a transaction, remove the following line or assign false # instead of true.
@@ -67,5 +71,10 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!            # The different available types are documented in the features, such as in # https://relishapp.com/rspec/rspec-rails/docs
   config.filter_rails_from_backtrace!                   # Filter lines from Rails gems in backtraces.
                                                         # arbitrary gems may also be filtered via: # config.filter_gems_from_backtrace("gem name")
+  config.include Capybara::DSL
+  Capybara.default_host = 'http://localhost:3000'
   config.include FactoryBot::Syntax::Methods
+
+  include StubGeocodeDenver
+
 end

--- a/spec/services/google_service_spec.rb
+++ b/spec/services/google_service_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+
+describe "Google Service" do
+
+  let(:location) { 'Denver,CO'  }
+  let(:lat)      {   39.7392358 }
+  let(:lng)      { -104.990251  }
+
+  before(:each) do
+    stub_geocode_denver
+  end
+
+  it 'gets location data' do
+    filter  = {target: :address, location: location}
+    service = GoogleService.new(filter)
+    json    = service.target_data
+    expect(json.class).to eq(Hash)
+    expect(json.keys).to include(:results)
+    expect(json.keys).to include(:status)
+    location = json[:results].first[:geometry][:location]
+    expect(location[:lat]).to eq(lat)
+    expect(location[:lng]).to eq(lng)
+  end
+
+end


### PR DESCRIPTION
Implement Google Geocode API.
Create a Coordinates PORO to return a string-pair of "lat,lng".
Create a ForecastHelper PORO to help create forecast to render json.

testing ✓


Start & Stop (saved for later) implementing geocoder gem for browser location. Was trying to mock/force an IP address in config/environments/development.rb & test.rb, but it's not necessary right now. Also not functional, and commented out, but source is cited.

