### PR TITLE
stubs added directly to test file

### DIFF
--- a/spec/fixtures/stub_all.rb
+++ b/spec/fixtures/stub_all.rb
@@ -2,7 +2,7 @@
 require './spec/fixtures/stub_geocode_denver'
 require './spec/fixtures/stub_dark_sky_denver'
 require './spec/fixtures/stub_gif_day_denver'
-require './spec/fixtures/stub_favorites'
+# require './spec/fixtures/stub_favorites'
 
 module StubAll
 
@@ -10,7 +10,7 @@ module StubAll
   include StubGeocodeDenver
   include StubDarkSkyDenver
   include StubGifDayDenver
-  include StubFavorites
+  # include StubFavorites
   # ^^^ if I keep this, then giphy tests break
   # ^^^ if I remove it (or move it anywhere above, favorite tests break)
 

--- a/spec/requests/can_get_user_favorites_spec.rb
+++ b/spec/requests/can_get_user_favorites_spec.rb
@@ -1,15 +1,20 @@
 require 'rails_helper'
 require 'api_helper'
 
+require './spec/fixtures/stub_favorites'
+
 RSpec.describe Api::V1::FavoritesController, type: :controller do
 
   include APIHelper
+  include StubFavorites
 
   let(:user)   { create(:user, token: '123abc') }
   let(:body)    { { api_key: user.token }.to_json }
   let(:headers) { { 'CONTENT_TYPE': 'application/json', 'ACCEPT': 'application/json' } }
 
   before(:each) do
+    stub_favorite_denver
+    stub_favorite_golden
     request.headers.merge!(headers)
   end
 


### PR DESCRIPTION
Still unsure of the stub conflict, but I added favorite#index related stubs directly to the test, and excluded them from the StubAll modules (included in rails_helper) -- all tests passing