### PR TITLE
user can delete a favorite

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,5 +5,18 @@ class ApplicationController < ActionController::Base
     @user ||= User.find_by_token( params[:api_key])
   end
 
+  def unauth(view = nil)
+    view ? 401 : (head 401)
+  end
+
+  def creation(view = nil)
+    view ? 201 : (head 201)
+  end
+
+  def ok(view = nil)
+    view ? 200 : (head 200)
+  end
+
+
 
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -3,14 +3,14 @@ class Favorite < ApplicationRecord
 
   belongs_to :user
   belongs_to :location
+  delegate :city, :state_short, :coordinates, to: :location, allow_nil: true
 
   validates_uniqueness_of :location, scope: [:user]
 
-
   # TO DO - Test me
   def joint_location
-    "#{location.city},#{location.state_short}"
+    # "#{location.city},#{location.state_short}"
+    "#{city},#{state_short}"
   end
-
 
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -6,6 +6,11 @@ class Location < ApplicationRecord
   has_many :favorites
   has_many :users, through: :favorites
 
+  # Location should be deleted if it has no favorites/users
+
+  # delegate :city,   to: :favorites
+  # delegate :state_short, to: :favorites
+
   # ASSUMPTION - only US States formatted City, State (no country)
   # If I only store coordinate, I can always have a location (anywhere)
   # HOWEVER, favorites#index needs to display a location string

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,14 @@ class User < ApplicationRecord
     user
   end
 
+  def specific_favorite(location)
+    # This should also confirm that state is in the short format
+    city, state = location.split(','); state.gsub!(' ', '')
+    self.favorites.joins(:location)
+                  .where(locations: {city: city, state_short: state})
+                  .first
+  end
+
   # TODO - make this private -- affects tests & factorybot
   # AND above method
   def generate_api_key

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
       resources :gifs,       only: [:index]
       resources :users,      only: [:create]
       resources :sessions,   only: [:create]
-      resources :favorites,  only: [:create, :index]
+      resources :favorites,  only: [:create, :index, :destroy]
     end
   end
 

--- a/spec/requests/user_can_delete_a_favorite_spec.rb
+++ b/spec/requests/user_can_delete_a_favorite_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+require 'api_helper'
+
+require './spec/fixtures/stub_favorites'
+
+
+RSpec.describe Api::V1::FavoritesController, type: :controller do
+
+  include APIHelper
+
+  include StubFavorites
+
+  let(:body) { { location: 'Denver, CO', api_key: "123abc" } }
+  let(:headers) { { 'CONTENT_TYPE': 'application/json', 'ACCEPT': 'application/json' } }
+
+  let(:user)    { create(:user, token: '123abc') }
+
+  before(:each) do
+    stub_favorite_denver
+    stub_favorite_golden
+    location = Location.create(city: 'Denver', state_short: 'CO', coordinates: '39.7392358,-104.990251' )
+    @fav = user.favorites.create(location: location)
+    request.headers.merge!(headers)
+  end
+
+  it 'failure' do
+    incorrect = body.dup; incorrect[:api_key] = "incorrect"
+    json      = incorrect.to_json
+    delete :destroy, params: {id: user}, body: json, format: :json, as: :json
+    expect(response.status).to eq(401)
+  end
+
+  describe 'success' do
+
+    before(:each) do
+      @json = body.to_json
+      stub_favorite_golden
+    end
+
+    # it 'returns 401 if deletes a favorite and there are NO FAVORITES' do
+    #   expect(Favorite.count).to eq(1)
+    #   delete :destroy, params: {id: user}, body: @json, format: :json, as: :json
+    #   expect(Favorite.count).to eq(0)
+    #   # expect(response.status).to eq(401)
+    #   expect(response.status).to eq(200)
+    # end
+
+    describe "More than one favorite" do
+
+      before(:each) do
+        loc2  = Location.create(city: 'Golden', state_short: 'CO', coordinates: '39.755543,-105.2210997' )
+        @fav2 = user.favorites.create(location: loc2)
+      end
+
+      it 'is successful' do
+        delete :destroy, params: {id: user}, body: @json, format: :json, as: :json
+        expect(response).to be_successful
+      end
+
+      it 'status 200' do
+        delete :destroy, params: {id: user}, body: @json, format: :json, as: :json
+        expect(response.status).to eq(200)
+      end
+
+      # Do we want to redirect to index or show the removed favorite ?
+      it 'deletes a favorite AND returns that deleted favorite' do
+        expect(Favorite.count).to eq(2)
+        delete :destroy, params: {id: user}, body: @json, format: :json, as: :json
+        expect(Favorite.count).to eq(1)
+        raw  = get_json[:data]
+        data = raw.first[:attributes]
+        expect(raw.count).to eq(1)
+        expect(data[:location]).to            eq("Denver,CO")
+        expect(data[:current_weather]).to_not be(nil)
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
 100% tested but unsure what the return page should actually be.
Assignment deletes Denver but both Denver and Golden are in the response - which looks like it was copied from user story 5 favorites#index. 

Currently the return is Denver, the deleted record.
IF the return should be the index, there are issues with redirecting, which returns status 302 and html 'you are being redirected' ... and not the evaluation of the index action.