### PR TITLE
skip auth_token for create user

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,7 +1,12 @@
 
 class Api::V1::UsersController < ApplicationController
 
+  # skip_before_filter :verify_authenticity_token
+  skip_before_action :verify_authenticity_token  
+
   def create
+    binding.pry
+
     @user = User.make_user(new_user)
     success if @user
   end


### PR DESCRIPTION
At this point for the [sweater_weather_FE](https://github.com/Kate-v2/sweater_weather_web) (issue [#7 registration](https://github.com/Kate-v2/sweater_weather_web/pull/23)), we are not using Authenticity_tokens, so for FE to interact with BE (this), I need to skip the verification in order to reach the end point.